### PR TITLE
add cascade r-cnn with fpn backbone

### DIFF
--- a/MODEL_ZOO.md
+++ b/MODEL_ZOO.md
@@ -52,7 +52,8 @@ All AP results are reported on minival2014 of the [COCO dataset](http://cocodata
 |Faster|R50v1-C4|C5-512ROI|1X|8X 1080Ti|2|no|8.4G|20 img/s|34.2|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/faster_r50v1c4_c5_512roi_1x.zip)|
 |Faster|R50v1-C4|C5-512ROI|1X|8X TitanV|2|yes|6.1G|49 img/s|34.4|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/faster_r50v1c4_c5_512roi_1x_fp16.zip)|
 |Faster|R50v2-C4|C5-256ROI|1X|8X 1080Ti|2|no|5.1G|33 img/s|32.8|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/faster_r50v2c4_c5_256roi_1x.zip)|
-|Cascade|R50v2-C5|2MLP|1X|8X 1080Ti|2|no|5.3G|27 img/s|37.5|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/cascade_r50v2_c5_red_1x.zip)|
+|Cascade|R50v2-C5|2MLP|1X|8X 1080Ti|2|no|5.9G|25 img/s|38.8|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/cascade_r50v2_c5_red_1x.zip)|
+|Cascade|R50v1-FPN|2MLP|1X|8X 1080Ti|2|no|6.6G|21 img/s|40.3|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/cascade_r50v1_fpn_1x.zip)|
 |Faster|R50v1-FPN|2MLP|1X|8X 1080Ti|2|no|5.2G|36 img/s|36.5|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/faster_r50v1_fpn_1x.zip)|
 |Mask|R50v1-FPN|2MLP+4CONV|1X|8X 1080Ti|2|no|6.7G|19 img/s|37.1(33.7)|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/mask_r50v1_fpn_1x.zip)|
 |Retina|R50v1-FPN|4Conv|1X|8X 1080Ti|2|no|5.1G|44 img/s|35.6|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/retina_r50v1_fpn_1x.zip)|
@@ -62,7 +63,8 @@ All AP results are reported on minival2014 of the [COCO dataset](http://cocodata
 |Faster|R101v1-C4|C5-512ROI|1X|8X 1080Ti|2|no|10.2G|16 img/s|38.3|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/faster_r101v1c4_c5_512roi_1x.zip)|
 |Faster|R101v1-C4|C5-512ROI|1X|8X TitanV|2|yes|7.0G|35 img/s|38.1|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/faster_r101v1c4_c5_512roi_1x_fp16.zip)|
 |Faster|R101v1-FPN|2MLP|1X|8X 1080Ti|2|no|7.5G|24 img/s|38.7|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/faster_r101v1_fpn_1x.zip)|
-|Cascade|R101v2-C5|2MLP|1X|8X 1080Ti|2|no|7.1G|23 img/s|40.0|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/cascade_r101v2_c5_red_1x.zip)|
+|Cascade|R101v2-C5|2MLP|1X|8X 1080Ti|2|no|7.6G|22 img/s|41.0|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/cascade_r101v2_c5_red_1x.zip)|
+|Cascade|R101v1-FPN|2MLP|1X|8X 1080Ti|2|no|8.7G|19 img/s|42.3|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/cascade_r101v1_fpn_1x.zip)|
 |Trident|R101v2-C4|C5-128ROI|1X|8X 1080Ti|1|no|6.6G|9 img/s|40.6|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/tridentnet_r101v2c4_c5_1x.zip)|
 |Trident-Fast|R101v2-C4|C5-128ROI|1X|8X 1080Ti|1|no|6.6G|9 img/s|39.9|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/tridentnet_r101v2c4_c5_fastapprox_1x.zip)|
 |Retina|R101v1-FPN|4Conv|1X|8X 1080Ti|2|no|7.1G|31 img/s|37.8|[model](https://simpledet-model.oss-cn-beijing.aliyuncs.com/retina_r101v1_fpn_1x.zip)|

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 - Modular design for coding-free exploration of new experiment settings
 
 ### Recent Updates
-- Add RPN test (2019.5.28)
-- Add [NASFPN](https://github.com/TuSimple/simpledet/tree/master/models/NASFPN) (2019.6.04)
-- Add new ResNetV1b baselines from GluonCV (2019.6.7)
+- Add RPN test (2019.05.28)
+- Add [NASFPN](https://github.com/TuSimple/simpledet/tree/master/models/NASFPN) (2019.06.04)
+- Add new ResNetV1b baselines from GluonCV (2019.06.07)
+- Add Cascade R-CNN with FPN backbone (2019.06.11)
 
 ### Setup
 #### Install

--- a/config/cascade_r101v1_fpn_1x.py
+++ b/config/cascade_r101v1_fpn_1x.py
@@ -1,0 +1,408 @@
+from models.cascade_rcnn.builder import CascadeRcnn as Detector
+from models.FPN.builder import MSRAResNet101V1FPN as Backbone
+from models.FPN.builder import FPNNeck as Neck
+from models.FPN.builder import FPNRpnHead as RpnHead
+from models.FPN.builder import FPNRoiAlign as RoiExtractor
+from models.cascade_rcnn.builder import CascadeBbox2fcHead as BboxHead
+from mxnext.complicate import normalizer_factory
+
+
+def get_config(is_train):
+    class General:
+        log_frequency = 10
+        name = __name__.rsplit("/")[-1].rsplit(".")[-1]
+        batch_image = 2 if is_train else 1
+        fp16 = False
+
+
+    class KvstoreParam:
+        kvstore     = "local"
+        batch_image = General.batch_image
+        gpus        = [0, 1, 2, 3, 4, 5, 6, 7]
+        fp16        = General.fp16
+
+
+    class NormalizeParam:
+        # normalizer = normalizer_factory(type="syncbn", ndev=len(KvstoreParam.gpus))
+        normalizer = normalizer_factory(type="fixbn")
+
+
+    class BackboneParam:
+        fp16 = General.fp16
+        normalizer = NormalizeParam.normalizer
+
+
+    class NeckParam:
+        fp16 = General.fp16
+        normalizer = NormalizeParam.normalizer
+        conv_channel = 256
+
+
+    class RpnParam:
+        fp16 = General.fp16
+        normalizer = NormalizeParam.normalizer
+        batch_image = General.batch_image
+
+        class anchor_generate:
+            scale = (8,)
+            ratio = (0.5, 1.0, 2.0)
+            stride = (4, 8, 16, 32, 64)
+            image_anchor = 256
+
+        class head:
+            conv_channel = 256
+            mean = (0, 0, 0, 0)
+            std = (1, 1, 1, 1)
+
+        class proposal:
+            pre_nms_top_n = 2000 if is_train else 1000
+            post_nms_top_n = 2000 if is_train else 1000
+            nms_thr = 0.7
+            min_bbox_side = 0
+
+        class subsample_proposal:
+            proposal_wo_gt = False
+            image_roi = 512
+            fg_fraction = 0.25
+            fg_thr = 0.5
+            bg_thr_hi = 0.5
+            bg_thr_lo = 0.0
+
+        class bbox_target:
+            num_reg_class = 2
+            class_agnostic = True
+            weight = (1.0, 1.0, 1.0, 1.0)
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.1, 0.1, 0.2, 0.2)
+
+
+    class BboxParam:
+        fp16        = General.fp16
+        normalizer  = NormalizeParam.normalizer
+        num_class   = 1 + 80
+        image_roi   = 512
+        batch_image = General.batch_image
+        stage       = "1st"
+        loss_weight = 1.0
+
+        class regress_target:
+            class_agnostic = True
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.1, 0.1, 0.2, 0.2)
+
+        class subsample_proposal:
+            proposal_wo_gt = False
+            image_roi = -1 # do not subsample rois
+            fg_fraction = 0.25
+            fg_thr = 0.6
+            bg_thr_hi = 0.6
+            bg_thr_lo = 0.0
+
+        class bbox_target:
+            num_reg_class = 2
+            class_agnostic = True
+            weight = (1.0, 1.0, 1.0, 1.0)
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.05, 0.05, 0.1, 0.1)
+
+
+    class BboxParam2nd:
+        fp16        = General.fp16
+        normalizer  = NormalizeParam.normalizer
+        num_class   = 1 + 80
+        image_roi   = 512
+        batch_image = General.batch_image
+        stage       = "2nd"
+        loss_weight = 0.5
+
+        class regress_target:
+            class_agnostic = True
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.05, 0.05, 0.1, 0.1)
+
+        class subsample_proposal:
+            proposal_wo_gt = False
+            image_roi = -1 # do not subsample rois
+            fg_fraction = 0.25
+            fg_thr = 0.7
+            bg_thr_hi = 0.7
+            bg_thr_lo = 0.0
+
+        class bbox_target:
+            num_reg_class = 2
+            class_agnostic = True
+            weight = (1.0, 1.0, 1.0, 1.0)
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.033, 0.033, 0.067, 0.067)
+
+    class BboxParam3rd:
+        fp16        = General.fp16
+        normalizer  = NormalizeParam.normalizer
+        num_class   = 1 + 80
+        image_roi   = 512
+        batch_image = General.batch_image
+        stage       = "3rd"
+        loss_weight = 0.25
+
+        class regress_target:
+            class_agnostic = True
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.033, 0.033, 0.067, 0.067)
+
+        class subsample_proposal:
+            proposal_wo_gt = None
+            image_roi = None
+            fg_fraction = None
+            fg_thr = None
+            bg_thr_hi = None
+            bg_thr_lo = None
+
+        class bbox_target:
+            num_reg_class = None
+            class_agnostic = None
+            weight = None
+            mean = None
+            std = None
+
+
+    class RoiParam:
+        fp16 = General.fp16
+        normalizer = NormalizeParam.normalizer
+        out_size = 7
+        stride = (4, 8, 16, 32)
+        roi_canonical_scale = 224
+        roi_canonical_level = 4
+
+
+    class DatasetParam:
+        if is_train:
+            image_set = ("coco_train2014", "coco_valminusminival2014")
+        else:
+            image_set = ("coco_minival2014", )
+
+    backbone = Backbone(BackboneParam)
+    neck = Neck(NeckParam)
+    rpn_head = RpnHead(RpnParam)
+    roi_extractor = RoiExtractor(RoiParam)
+    bbox_head = BboxHead(BboxParam)
+    bbox_head_2nd = BboxHead(BboxParam2nd)
+    bbox_head_3rd = BboxHead(BboxParam3rd)
+    detector = Detector()
+    if is_train:
+        train_sym = detector.get_train_symbol(
+            backbone,
+            neck,
+            rpn_head,
+            roi_extractor,
+            bbox_head,
+            bbox_head_2nd,
+            bbox_head_3rd
+        )
+        rpn_test_sym = None
+        test_sym = None
+    else:
+        train_sym = None
+        rpn_test_sym = detector.get_rpn_test_symbol(backbone, neck, rpn_head)
+        test_sym = detector.get_test_symbol(
+            backbone,
+            neck,
+            rpn_head,
+            roi_extractor,
+            bbox_head,
+            bbox_head_2nd,
+            bbox_head_3rd
+        )
+
+
+    class ModelParam:
+        train_symbol = train_sym
+        test_symbol = test_sym
+        rpn_test_symbol = rpn_test_sym
+
+        from_scratch = False
+        random = True
+        memonger = False
+        memonger_until = "stage3_unit21_plus"
+
+        class pretrain:
+            prefix = "pretrain_model/resnet-v1-101"
+            epoch = 0
+            fixed_param = ["conv0", "stage1", "gamma", "beta"]
+
+
+    class OptimizeParam:
+        class optimizer:
+            type = "sgd"
+            lr = 0.01 / 8 * len(KvstoreParam.gpus) * KvstoreParam.batch_image
+            momentum = 0.9
+            wd = 0.0001
+            clip_gradient = None
+
+        class schedule:
+            begin_epoch = 0
+            end_epoch = 6
+            lr_iter = [60000 * 16 // (len(KvstoreParam.gpus) * KvstoreParam.batch_image),
+                       80000 * 16 // (len(KvstoreParam.gpus) * KvstoreParam.batch_image)]
+
+        class warmup:
+            type = "gradual"
+            lr = 0.01 / 8 * len(KvstoreParam.gpus) * KvstoreParam.batch_image / 3.0
+            iter = 500
+
+
+    class TestParam:
+        min_det_score = 0.05
+        max_det_per_image = 100
+
+        process_roidb = lambda x: x
+        process_output = lambda x, y: x
+
+        class model:
+            prefix = "experiments/{}/checkpoint".format(General.name)
+            epoch = OptimizeParam.schedule.end_epoch
+
+        class nms:
+            type = "nms"
+            thr = 0.5
+
+        class coco:
+            annotation = "data/coco/annotations/instances_minival2014.json"
+
+
+    # data processing
+    class NormParam:
+        mean = (122.7717, 115.9465, 102.9801) # RGB order
+        std = (1.0, 1.0, 1.0)
+
+    # data processing
+    class ResizeParam:
+        short = 800
+        long = 1333
+
+
+    class PadParam:
+        short = 800
+        long = 1333
+        max_num_gt = 100
+
+
+    class AnchorTarget2DParam:
+        def __init__(self):
+            self.generate = self._generate()
+            self.mean = (0, 0, 0, 0)
+            self.std = (1, 1, 1, 1)
+
+        class _generate:
+            def __init__(self):
+                self.stride = (4, 8, 16, 32, 64)
+                self.short = (200, 100, 50, 25, 13)
+                self.long = (334, 167, 84, 42, 21)
+            scales = (8,)
+            aspects = (0.5, 1.0, 2.0)
+
+        class assign:
+            allowed_border = 0
+            pos_thr = 0.7
+            neg_thr = 0.3
+            min_pos_thr = 0.0
+
+        class sample:
+            image_anchor = 256
+            pos_fraction = 0.5
+
+
+    class RenameParam:
+        mapping = dict(image="data")
+
+
+    from core.detection_input import ReadRoiRecord, Resize2DImageBbox, \
+        ConvertImageFromHwcToChw, Flip2DImageBbox, Pad2DImageBbox, \
+        RenameRecord, Norm2DImage
+
+    from models.FPN.input import PyramidAnchorTarget2D
+
+    if is_train:
+        transform = [
+            ReadRoiRecord(None),
+            Norm2DImage(NormParam),
+            Resize2DImageBbox(ResizeParam),
+            Flip2DImageBbox(),
+            Pad2DImageBbox(PadParam),
+            ConvertImageFromHwcToChw(),
+            PyramidAnchorTarget2D(AnchorTarget2DParam()),
+            RenameRecord(RenameParam.mapping)
+        ]
+        data_name = ["data", "im_info", "gt_bbox"]
+        label_name = ["rpn_cls_label", "rpn_reg_target", "rpn_reg_weight"]
+    else:
+        transform = [
+            ReadRoiRecord(None),
+            Norm2DImage(NormParam),
+            Resize2DImageBbox(ResizeParam),
+            ConvertImageFromHwcToChw(),
+            RenameRecord(RenameParam.mapping)
+        ]
+        data_name = ["data", "im_info", "im_id", "rec_id"]
+        label_name = []
+
+    import core.detection_metric as metric
+
+    rpn_acc_metric = metric.AccWithIgnore(
+        "RpnAcc",
+        ["rpn_cls_loss_output"],
+        ["rpn_cls_label"]
+    )
+    rpn_l1_metric = metric.L1(
+        "RpnL1",
+        ["rpn_reg_loss_output"],
+        ["rpn_cls_label"]
+    )
+    # for bbox, the label is generated in network so it is an output
+    # stage1 metric
+    box_acc_metric_1st = metric.AccWithIgnore(
+        "RcnnAcc_1st",
+        ["bbox_cls_loss_1st_output", "bbox_label_blockgrad_1st_output"],
+        []
+    )
+    box_l1_metric_1st = metric.L1(
+        "RcnnL1_1st",
+        ["bbox_reg_loss_1st_output", "bbox_label_blockgrad_1st_output"],
+        []
+    )
+    # stage2 metric
+    box_acc_metric_2nd = metric.AccWithIgnore(
+        "RcnnAcc_2nd",
+        ["bbox_cls_loss_2nd_output", "bbox_label_blockgrad_2nd_output"],
+        []
+    )
+    box_l1_metric_2nd = metric.L1(
+        "RcnnL1_2nd",
+        ["bbox_reg_loss_2nd_output", "bbox_label_blockgrad_2nd_output"],
+        []
+    )
+    # stage3 metric
+    box_acc_metric_3rd = metric.AccWithIgnore(
+        "RcnnAcc_3rd",
+        ["bbox_cls_loss_3rd_output", "bbox_label_blockgrad_3rd_output"],
+        []
+    )
+    box_l1_metric_3rd = metric.L1(
+        "RcnnL1_3rd",
+        ["bbox_reg_loss_3rd_output", "bbox_label_blockgrad_3rd_output"],
+        []
+    )
+
+    metric_list = [
+        rpn_acc_metric,
+        rpn_l1_metric,
+        box_acc_metric_1st,
+        box_l1_metric_1st,
+        box_acc_metric_2nd,
+        box_l1_metric_2nd,
+        box_acc_metric_3rd,
+        box_l1_metric_3rd
+    ]
+
+    return General, KvstoreParam, RpnParam, RoiParam, BboxParam, DatasetParam, \
+           ModelParam, OptimizeParam, TestParam, \
+           transform, data_name, label_name, metric_list

--- a/config/cascade_r101v1_fpn_1x.py
+++ b/config/cascade_r101v1_fpn_1x.py
@@ -92,7 +92,7 @@ def get_config(is_train):
 
         class subsample_proposal:
             proposal_wo_gt = False
-            image_roi = -1 # do not subsample rois
+            image_roi = 512
             fg_fraction = 0.25
             fg_thr = 0.6
             bg_thr_hi = 0.6
@@ -122,7 +122,7 @@ def get_config(is_train):
 
         class subsample_proposal:
             proposal_wo_gt = False
-            image_roi = -1 # do not subsample rois
+            image_roi = 512
             fg_fraction = 0.25
             fg_thr = 0.7
             bg_thr_hi = 0.7

--- a/config/cascade_r101v1_fpn_1x.py
+++ b/config/cascade_r101v1_fpn_1x.py
@@ -35,7 +35,6 @@ def get_config(is_train):
     class NeckParam:
         fp16 = General.fp16
         normalizer = NormalizeParam.normalizer
-        conv_channel = 256
 
 
     class RpnParam:

--- a/config/cascade_r101v2_c5_red_1x.py
+++ b/config/cascade_r101v2_c5_red_1x.py
@@ -61,7 +61,7 @@ def get_config(is_train):
             min_bbox_side = 0
 
         class subsample_proposal:
-            proposal_wo_gt = True
+            proposal_wo_gt = False
             image_roi = 256
             fg_fraction = 0.25
             fg_thr = 0.5
@@ -91,7 +91,7 @@ def get_config(is_train):
             std = (0.1, 0.1, 0.2, 0.2)
 
         class subsample_proposal:
-            proposal_wo_gt = True
+            proposal_wo_gt = False
             image_roi = 256
             fg_fraction = 0.25
             fg_thr = 0.6
@@ -121,7 +121,7 @@ def get_config(is_train):
             std = (0.05, 0.05, 0.1, 0.1)
 
         class subsample_proposal:
-            proposal_wo_gt = True
+            proposal_wo_gt = False
             image_roi = 256
             fg_fraction = 0.25
             fg_thr = 0.7

--- a/config/cascade_r101v2_c5_red_1x.py
+++ b/config/cascade_r101v2_c5_red_1x.py
@@ -83,12 +83,12 @@ def get_config(is_train):
         image_roi   = 256
         batch_image = General.batch_image
         stage       = "1st"
+        loss_weight = 1.0
 
         class regress_target:
             class_agnostic = True
             mean = (0.0, 0.0, 0.0, 0.0)
             std = (0.1, 0.1, 0.2, 0.2)
-            loss_weight = 1.0
 
         class subsample_proposal:
             proposal_wo_gt = True
@@ -113,12 +113,12 @@ def get_config(is_train):
         image_roi   = 256
         batch_image = General.batch_image
         stage       = "2nd"
+        loss_weight = 0.5
 
         class regress_target:
             class_agnostic = True
             mean = (0.0, 0.0, 0.0, 0.0)
             std = (0.05, 0.05, 0.1, 0.1)
-            loss_weight = 0.5
 
         class subsample_proposal:
             proposal_wo_gt = True
@@ -142,12 +142,12 @@ def get_config(is_train):
         image_roi   = 256
         batch_image = General.batch_image
         stage       = "3rd"
+        loss_weight = 0.25
 
         class regress_target:
             class_agnostic = True
             mean = (0.0, 0.0, 0.0, 0.0)
             std = (0.033, 0.033, 0.067, 0.067)
-            loss_weight = 0.25
 
         class subsample_proposal:
             proposal_wo_gt = None

--- a/config/cascade_r101v2_c5_red_1x.py
+++ b/config/cascade_r101v2_c5_red_1x.py
@@ -2,7 +2,7 @@ from models.cascade_rcnn.builder import CascadeRcnn as Detector
 from symbol.builder import MXNetResNet101V2C4C5 as Backbone
 from models.cascade_rcnn.builder import CascadeNeck as Neck
 from symbol.builder import RpnHead
-from models.cascade_rcnn.builder import CascadeRoiAlign as RoiExtractor
+from symbol.builder import RoiAlign as RoiExtractor
 from models.cascade_rcnn.builder import CascadeBbox2fcHead as BboxHead
 from mxnext.complicate import normalizer_factory
 

--- a/config/cascade_r101v2_c5_red_1x.py
+++ b/config/cascade_r101v2_c5_red_1x.py
@@ -35,7 +35,9 @@ def get_config(is_train):
     class NeckParam:
         fp16 = General.fp16
         normalizer = NormalizeParam.normalizer
-        conv_channel = 1024
+
+        class reduce:
+            channel = 1024
 
 
     class RpnParam:
@@ -234,7 +236,7 @@ def get_config(is_train):
             lr = 0.01 / 8 * len(KvstoreParam.gpus) * KvstoreParam.batch_image
             momentum = 0.9
             wd = 0.0001
-            clip_gradient = 35
+            clip_gradient = None
 
         class schedule:
             begin_epoch = 0

--- a/config/cascade_r101v2_c5_red_1x.py
+++ b/config/cascade_r101v2_c5_red_1x.py
@@ -1,6 +1,6 @@
 from models.cascade_rcnn.builder import CascadeRcnn as Detector
 from symbol.builder import MXNetResNet101V2C4C5 as Backbone
-from models.cascade_rcnn.builder import CascadeNeck as Neck
+from symbol.builder import ReduceNeck as Neck
 from symbol.builder import RpnHead
 from symbol.builder import RoiAlign as RoiExtractor
 from models.cascade_rcnn.builder import CascadeBbox2fcHead as BboxHead

--- a/config/cascade_r50v1_fpn_1x.py
+++ b/config/cascade_r50v1_fpn_1x.py
@@ -1,0 +1,408 @@
+from models.cascade_rcnn.builder import CascadeRcnn as Detector
+from models.FPN.builder import MSRAResNet50V1FPN as Backbone
+from models.FPN.builder import FPNNeck as Neck
+from models.FPN.builder import FPNRpnHead as RpnHead
+from models.FPN.builder import FPNRoiAlign as RoiExtractor
+from models.cascade_rcnn.builder import CascadeBbox2fcHead as BboxHead
+from mxnext.complicate import normalizer_factory
+
+
+def get_config(is_train):
+    class General:
+        log_frequency = 10
+        name = __name__.rsplit("/")[-1].rsplit(".")[-1]
+        batch_image = 2 if is_train else 1
+        fp16 = False
+
+
+    class KvstoreParam:
+        kvstore     = "local"
+        batch_image = General.batch_image
+        gpus        = [0, 1, 2, 3, 4, 5, 6, 7]
+        fp16        = General.fp16
+
+
+    class NormalizeParam:
+        # normalizer = normalizer_factory(type="syncbn", ndev=len(KvstoreParam.gpus))
+        normalizer = normalizer_factory(type="fixbn")
+
+
+    class BackboneParam:
+        fp16 = General.fp16
+        normalizer = NormalizeParam.normalizer
+
+
+    class NeckParam:
+        fp16 = General.fp16
+        normalizer = NormalizeParam.normalizer
+        conv_channel = 256
+
+
+    class RpnParam:
+        fp16 = General.fp16
+        normalizer = NormalizeParam.normalizer
+        batch_image = General.batch_image
+
+        class anchor_generate:
+            scale = (8,)
+            ratio = (0.5, 1.0, 2.0)
+            stride = (4, 8, 16, 32, 64)
+            image_anchor = 256
+
+        class head:
+            conv_channel = 256
+            mean = (0, 0, 0, 0)
+            std = (1, 1, 1, 1)
+
+        class proposal:
+            pre_nms_top_n = 2000 if is_train else 1000
+            post_nms_top_n = 2000 if is_train else 1000
+            nms_thr = 0.7
+            min_bbox_side = 0
+
+        class subsample_proposal:
+            proposal_wo_gt = False
+            image_roi = 512
+            fg_fraction = 0.25
+            fg_thr = 0.5
+            bg_thr_hi = 0.5
+            bg_thr_lo = 0.0
+
+        class bbox_target:
+            num_reg_class = 2
+            class_agnostic = True
+            weight = (1.0, 1.0, 1.0, 1.0)
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.1, 0.1, 0.2, 0.2)
+
+
+    class BboxParam:
+        fp16        = General.fp16
+        normalizer  = NormalizeParam.normalizer
+        num_class   = 1 + 80
+        image_roi   = 512
+        batch_image = General.batch_image
+        stage       = "1st"
+        loss_weight = 1.0
+
+        class regress_target:
+            class_agnostic = True
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.1, 0.1, 0.2, 0.2)
+
+        class subsample_proposal:
+            proposal_wo_gt = False
+            image_roi = -1 # do not subsample rois
+            fg_fraction = 0.25
+            fg_thr = 0.6
+            bg_thr_hi = 0.6
+            bg_thr_lo = 0.0
+
+        class bbox_target:
+            num_reg_class = 2
+            class_agnostic = True
+            weight = (1.0, 1.0, 1.0, 1.0)
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.05, 0.05, 0.1, 0.1)
+
+
+    class BboxParam2nd:
+        fp16        = General.fp16
+        normalizer  = NormalizeParam.normalizer
+        num_class   = 1 + 80
+        image_roi   = 512
+        batch_image = General.batch_image
+        stage       = "2nd"
+        loss_weight = 0.5
+
+        class regress_target:
+            class_agnostic = True
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.05, 0.05, 0.1, 0.1)
+
+        class subsample_proposal:
+            proposal_wo_gt = False
+            image_roi = -1 # do not subsample rois
+            fg_fraction = 0.25
+            fg_thr = 0.7
+            bg_thr_hi = 0.7
+            bg_thr_lo = 0.0
+
+        class bbox_target:
+            num_reg_class = 2
+            class_agnostic = True
+            weight = (1.0, 1.0, 1.0, 1.0)
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.033, 0.033, 0.067, 0.067)
+
+    class BboxParam3rd:
+        fp16        = General.fp16
+        normalizer  = NormalizeParam.normalizer
+        num_class   = 1 + 80
+        image_roi   = 512
+        batch_image = General.batch_image
+        stage       = "3rd"
+        loss_weight = 0.25
+
+        class regress_target:
+            class_agnostic = True
+            mean = (0.0, 0.0, 0.0, 0.0)
+            std = (0.033, 0.033, 0.067, 0.067)
+
+        class subsample_proposal:
+            proposal_wo_gt = None
+            image_roi = None
+            fg_fraction = None
+            fg_thr = None
+            bg_thr_hi = None
+            bg_thr_lo = None
+
+        class bbox_target:
+            num_reg_class = None
+            class_agnostic = None
+            weight = None
+            mean = None
+            std = None
+
+
+    class RoiParam:
+        fp16 = General.fp16
+        normalizer = NormalizeParam.normalizer
+        out_size = 7
+        stride = (4, 8, 16, 32)
+        roi_canonical_scale = 224
+        roi_canonical_level = 4
+
+
+    class DatasetParam:
+        if is_train:
+            image_set = ("coco_train2014", "coco_valminusminival2014")
+        else:
+            image_set = ("coco_minival2014", )
+
+    backbone = Backbone(BackboneParam)
+    neck = Neck(NeckParam)
+    rpn_head = RpnHead(RpnParam)
+    roi_extractor = RoiExtractor(RoiParam)
+    bbox_head = BboxHead(BboxParam)
+    bbox_head_2nd = BboxHead(BboxParam2nd)
+    bbox_head_3rd = BboxHead(BboxParam3rd)
+    detector = Detector()
+    if is_train:
+        train_sym = detector.get_train_symbol(
+            backbone,
+            neck,
+            rpn_head,
+            roi_extractor,
+            bbox_head,
+            bbox_head_2nd,
+            bbox_head_3rd
+        )
+        rpn_test_sym = None
+        test_sym = None
+    else:
+        train_sym = None
+        rpn_test_sym = detector.get_rpn_test_symbol(backbone, neck, rpn_head)
+        test_sym = detector.get_test_symbol(
+            backbone,
+            neck,
+            rpn_head,
+            roi_extractor,
+            bbox_head,
+            bbox_head_2nd,
+            bbox_head_3rd
+        )
+
+
+    class ModelParam:
+        train_symbol = train_sym
+        test_symbol = test_sym
+        rpn_test_symbol = rpn_test_sym
+
+        from_scratch = False
+        random = True
+        memonger = False
+        memonger_until = "stage3_unit21_plus"
+
+        class pretrain:
+            prefix = "pretrain_model/resnet-v1-50"
+            epoch = 0
+            fixed_param = ["conv0", "stage1", "gamma", "beta"]
+
+
+    class OptimizeParam:
+        class optimizer:
+            type = "sgd"
+            lr = 0.01 / 8 * len(KvstoreParam.gpus) * KvstoreParam.batch_image
+            momentum = 0.9
+            wd = 0.0001
+            clip_gradient = None
+
+        class schedule:
+            begin_epoch = 0
+            end_epoch = 6
+            lr_iter = [60000 * 16 // (len(KvstoreParam.gpus) * KvstoreParam.batch_image),
+                       80000 * 16 // (len(KvstoreParam.gpus) * KvstoreParam.batch_image)]
+
+        class warmup:
+            type = "gradual"
+            lr = 0.01 / 8 * len(KvstoreParam.gpus) * KvstoreParam.batch_image / 3.0
+            iter = 500
+
+
+    class TestParam:
+        min_det_score = 0.05
+        max_det_per_image = 100
+
+        process_roidb = lambda x: x
+        process_output = lambda x, y: x
+
+        class model:
+            prefix = "experiments/{}/checkpoint".format(General.name)
+            epoch = OptimizeParam.schedule.end_epoch
+
+        class nms:
+            type = "nms"
+            thr = 0.5
+
+        class coco:
+            annotation = "data/coco/annotations/instances_minival2014.json"
+
+
+    # data processing
+    class NormParam:
+        mean = (122.7717, 115.9465, 102.9801) # RGB order
+        std = (1.0, 1.0, 1.0)
+
+    # data processing
+    class ResizeParam:
+        short = 800
+        long = 1333
+
+
+    class PadParam:
+        short = 800
+        long = 1333
+        max_num_gt = 100
+
+
+    class AnchorTarget2DParam:
+        def __init__(self):
+            self.generate = self._generate()
+            self.mean = (0, 0, 0, 0)
+            self.std = (1, 1, 1, 1)
+
+        class _generate:
+            def __init__(self):
+                self.stride = (4, 8, 16, 32, 64)
+                self.short = (200, 100, 50, 25, 13)
+                self.long = (334, 167, 84, 42, 21)
+            scales = (8,)
+            aspects = (0.5, 1.0, 2.0)
+
+        class assign:
+            allowed_border = 0
+            pos_thr = 0.7
+            neg_thr = 0.3
+            min_pos_thr = 0.0
+
+        class sample:
+            image_anchor = 256
+            pos_fraction = 0.5
+
+
+    class RenameParam:
+        mapping = dict(image="data")
+
+
+    from core.detection_input import ReadRoiRecord, Resize2DImageBbox, \
+        ConvertImageFromHwcToChw, Flip2DImageBbox, Pad2DImageBbox, \
+        RenameRecord, Norm2DImage
+
+    from models.FPN.input import PyramidAnchorTarget2D
+
+    if is_train:
+        transform = [
+            ReadRoiRecord(None),
+            Norm2DImage(NormParam),
+            Resize2DImageBbox(ResizeParam),
+            Flip2DImageBbox(),
+            Pad2DImageBbox(PadParam),
+            ConvertImageFromHwcToChw(),
+            PyramidAnchorTarget2D(AnchorTarget2DParam()),
+            RenameRecord(RenameParam.mapping)
+        ]
+        data_name = ["data", "im_info", "gt_bbox"]
+        label_name = ["rpn_cls_label", "rpn_reg_target", "rpn_reg_weight"]
+    else:
+        transform = [
+            ReadRoiRecord(None),
+            Norm2DImage(NormParam),
+            Resize2DImageBbox(ResizeParam),
+            ConvertImageFromHwcToChw(),
+            RenameRecord(RenameParam.mapping)
+        ]
+        data_name = ["data", "im_info", "im_id", "rec_id"]
+        label_name = []
+
+    import core.detection_metric as metric
+
+    rpn_acc_metric = metric.AccWithIgnore(
+        "RpnAcc",
+        ["rpn_cls_loss_output"],
+        ["rpn_cls_label"]
+    )
+    rpn_l1_metric = metric.L1(
+        "RpnL1",
+        ["rpn_reg_loss_output"],
+        ["rpn_cls_label"]
+    )
+    # for bbox, the label is generated in network so it is an output
+    # stage1 metric
+    box_acc_metric_1st = metric.AccWithIgnore(
+        "RcnnAcc_1st",
+        ["bbox_cls_loss_1st_output", "bbox_label_blockgrad_1st_output"],
+        []
+    )
+    box_l1_metric_1st = metric.L1(
+        "RcnnL1_1st",
+        ["bbox_reg_loss_1st_output", "bbox_label_blockgrad_1st_output"],
+        []
+    )
+    # stage2 metric
+    box_acc_metric_2nd = metric.AccWithIgnore(
+        "RcnnAcc_2nd",
+        ["bbox_cls_loss_2nd_output", "bbox_label_blockgrad_2nd_output"],
+        []
+    )
+    box_l1_metric_2nd = metric.L1(
+        "RcnnL1_2nd",
+        ["bbox_reg_loss_2nd_output", "bbox_label_blockgrad_2nd_output"],
+        []
+    )
+    # stage3 metric
+    box_acc_metric_3rd = metric.AccWithIgnore(
+        "RcnnAcc_3rd",
+        ["bbox_cls_loss_3rd_output", "bbox_label_blockgrad_3rd_output"],
+        []
+    )
+    box_l1_metric_3rd = metric.L1(
+        "RcnnL1_3rd",
+        ["bbox_reg_loss_3rd_output", "bbox_label_blockgrad_3rd_output"],
+        []
+    )
+
+    metric_list = [
+        rpn_acc_metric,
+        rpn_l1_metric,
+        box_acc_metric_1st,
+        box_l1_metric_1st,
+        box_acc_metric_2nd,
+        box_l1_metric_2nd,
+        box_acc_metric_3rd,
+        box_l1_metric_3rd
+    ]
+
+    return General, KvstoreParam, RpnParam, RoiParam, BboxParam, DatasetParam, \
+           ModelParam, OptimizeParam, TestParam, \
+           transform, data_name, label_name, metric_list

--- a/config/cascade_r50v1_fpn_1x.py
+++ b/config/cascade_r50v1_fpn_1x.py
@@ -92,7 +92,7 @@ def get_config(is_train):
 
         class subsample_proposal:
             proposal_wo_gt = False
-            image_roi = -1 # do not subsample rois
+            image_roi = 512
             fg_fraction = 0.25
             fg_thr = 0.6
             bg_thr_hi = 0.6
@@ -122,7 +122,7 @@ def get_config(is_train):
 
         class subsample_proposal:
             proposal_wo_gt = False
-            image_roi = -1 # do not subsample rois
+            image_roi = 512
             fg_fraction = 0.25
             fg_thr = 0.7
             bg_thr_hi = 0.7

--- a/config/cascade_r50v1_fpn_1x.py
+++ b/config/cascade_r50v1_fpn_1x.py
@@ -35,7 +35,6 @@ def get_config(is_train):
     class NeckParam:
         fp16 = General.fp16
         normalizer = NormalizeParam.normalizer
-        conv_channel = 256
 
 
     class RpnParam:

--- a/config/cascade_r50v2_c5_red_1x.py
+++ b/config/cascade_r50v2_c5_red_1x.py
@@ -61,7 +61,7 @@ def get_config(is_train):
             min_bbox_side = 0
 
         class subsample_proposal:
-            proposal_wo_gt = True
+            proposal_wo_gt = False
             image_roi = 256
             fg_fraction = 0.25
             fg_thr = 0.5
@@ -91,7 +91,7 @@ def get_config(is_train):
             std = (0.1, 0.1, 0.2, 0.2)
 
         class subsample_proposal:
-            proposal_wo_gt = True
+            proposal_wo_gt = False
             image_roi = 256
             fg_fraction = 0.25
             fg_thr = 0.6
@@ -121,7 +121,7 @@ def get_config(is_train):
             std = (0.05, 0.05, 0.1, 0.1)
 
         class subsample_proposal:
-            proposal_wo_gt = True
+            proposal_wo_gt = False
             image_roi = 256
             fg_fraction = 0.25
             fg_thr = 0.7

--- a/config/cascade_r50v2_c5_red_1x.py
+++ b/config/cascade_r50v2_c5_red_1x.py
@@ -83,12 +83,12 @@ def get_config(is_train):
         image_roi   = 256
         batch_image = General.batch_image
         stage       = "1st"
+        loss_weight = 1.0
 
         class regress_target:
             class_agnostic = True
             mean = (0.0, 0.0, 0.0, 0.0)
             std = (0.1, 0.1, 0.2, 0.2)
-            loss_weight = 1.0
 
         class subsample_proposal:
             proposal_wo_gt = True
@@ -113,12 +113,12 @@ def get_config(is_train):
         image_roi   = 256
         batch_image = General.batch_image
         stage       = "2nd"
+        loss_weight = 0.5
 
         class regress_target:
             class_agnostic = True
             mean = (0.0, 0.0, 0.0, 0.0)
             std = (0.05, 0.05, 0.1, 0.1)
-            loss_weight = 0.5
 
         class subsample_proposal:
             proposal_wo_gt = True
@@ -142,12 +142,12 @@ def get_config(is_train):
         image_roi   = 256
         batch_image = General.batch_image
         stage       = "3rd"
+        loss_weight = 0.25
 
         class regress_target:
             class_agnostic = True
             mean = (0.0, 0.0, 0.0, 0.0)
             std = (0.033, 0.033, 0.067, 0.067)
-            loss_weight = 0.25
 
         class subsample_proposal:
             proposal_wo_gt = None

--- a/config/cascade_r50v2_c5_red_1x.py
+++ b/config/cascade_r50v2_c5_red_1x.py
@@ -35,7 +35,9 @@ def get_config(is_train):
     class NeckParam:
         fp16 = General.fp16
         normalizer = NormalizeParam.normalizer
-        conv_channel = 1024
+
+        class reduce:
+            channel = 1024
 
 
     class RpnParam:
@@ -234,7 +236,7 @@ def get_config(is_train):
             lr = 0.01 / 8 * len(KvstoreParam.gpus) * KvstoreParam.batch_image
             momentum = 0.9
             wd = 0.0001
-            clip_gradient = 35
+            clip_gradient = None
 
         class schedule:
             begin_epoch = 0

--- a/config/cascade_r50v2_c5_red_1x.py
+++ b/config/cascade_r50v2_c5_red_1x.py
@@ -2,7 +2,7 @@ from models.cascade_rcnn.builder import CascadeRcnn as Detector
 from symbol.builder import MXNetResNet50V2C4C5 as Backbone
 from models.cascade_rcnn.builder import CascadeNeck as Neck
 from symbol.builder import RpnHead
-from models.cascade_rcnn.builder import CascadeRoiAlign as RoiExtractor
+from symbol.builder import RoiAlign as RoiExtractor
 from models.cascade_rcnn.builder import CascadeBbox2fcHead as BboxHead
 from mxnext.complicate import normalizer_factory
 

--- a/config/cascade_r50v2_c5_red_1x.py
+++ b/config/cascade_r50v2_c5_red_1x.py
@@ -1,6 +1,6 @@
 from models.cascade_rcnn.builder import CascadeRcnn as Detector
 from symbol.builder import MXNetResNet50V2C4C5 as Backbone
-from models.cascade_rcnn.builder import CascadeNeck as Neck
+from symbol.builder import ReduceNeck as Neck
 from symbol.builder import RpnHead
 from symbol.builder import RoiAlign as RoiExtractor
 from models.cascade_rcnn.builder import CascadeBbox2fcHead as BboxHead

--- a/models/cascade_rcnn/README.md
+++ b/models/cascade_rcnn/README.md
@@ -1,6 +1,6 @@
 ## Cascade R-CNN
 
-This repository implements [**Cascade R-CNN**](https://arxiv.org/abs/1712.00726) in the **SimpleDet** framework. Cascade R-CNN is a multi-stage object detector, aiming to reduce the overfitting problem by resampling of progressively improved hypotheses. Currently, we only provide Cascade R-CNN based on Faster R-CNN without FPN.
+This repository implements [**Cascade R-CNN**](https://arxiv.org/abs/1712.00726) in the **SimpleDet** framework. Cascade R-CNN is a multi-stage object detector, aiming to reduce the overfitting problem by resampling of progressively improved hypotheses.
 
 ### How we build Cascade R-CNN
 
@@ -11,9 +11,6 @@ Cascade R-CNN can share the origin Faster R-CNN input, so there is no need to im
 #### Symbol
 
 - ```CascadeRcnn```: detector with three ```R-CNN``` stages
-
-- ```CascadeNeck```: neck to reduce feature channels for speedup, default ```conv_channel``` is set to 1024
-- ```CascadeRoiAlign```: ```RoiExtractor``` for ```R-CNN``` stages
 - ```CascadeBbox2fcHead```: header for ```R-CNN``` stages. Note that it is also required to generate proposal for next ```R-CNN``` stages, thus we add ```get_all_proposal``` to decode boxes predicted in this stage and ```get_sampled_proposal``` to generate ```bbox_target```.
 
 #### Config

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import math
 import mxnext as X
 
-from symbol.builder import FasterRcnn, Neck, RoiAlign, Bbox2fcHead
+from symbol.builder import FasterRcnn, Bbox2fcHead
 
 class CascadeRcnn(object):
     def __init__(self):

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -396,7 +396,7 @@ class CascadeBbox2fcHead(Bbox2fcHead):
         batch_image = p.batch_image
 
         proposal_wo_gt = p.subsample_proposal.proposal_wo_gt
-        image_roi = -1 # do not subsample rois
+        image_roi = p.subsample_proposal.image_roi
         fg_fraction = p.subsample_proposal.fg_fraction
         fg_thr = p.subsample_proposal.fg_thr
         bg_thr_hi = p.subsample_proposal.bg_thr_hi

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -215,8 +215,9 @@ class CascadeBbox2fcHead(Bbox2fcHead):
 
 
     def _get_bbox_head_logit(self, conv_feat):
-        #if self._head_feat is not None:
-        #    return self._head_feat
+        # comment this for re-infer in test stage
+        # if self._head_feat is not None:
+        #     return self._head_feat
 
         stage = self.stage
 

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -315,7 +315,7 @@ class CascadeBbox2fcHead(Bbox2fcHead):
     def get_loss(self, conv_feat, cls_label, bbox_target, bbox_weight):
         p = self.p
         stage = self.stage
-        loss_weight = p.regress_target.loss_weight
+        loss_weight = p.loss_weight
         batch_roi = p.image_roi * p.batch_image
         batch_image = p.batch_image
 

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -33,7 +33,7 @@ class CascadeRcnn(object):
                 gt_bbox,
                 im_info
             )
-        roi_feat = roi_extractor.get_roi_feature(rcnn_feat, proposal, "1st")
+        roi_feat = roi_extractor.get_roi_feature(rcnn_feat, proposal)
         bbox_loss = bbox_head.get_loss(
             roi_feat,
             bbox_cls,
@@ -51,7 +51,7 @@ class CascadeRcnn(object):
                 gt_bbox,
                 im_info
             )
-        roi_feat_2nd = roi_extractor.get_roi_feature(rcnn_feat, proposal_2nd, "2nd")
+        roi_feat_2nd = roi_extractor.get_roi_feature(rcnn_feat, proposal_2nd)
         bbox_loss_2nd = bbox_head_2nd.get_loss(
             roi_feat_2nd,
             bbox_cls_2nd,
@@ -69,7 +69,7 @@ class CascadeRcnn(object):
                 gt_bbox,
                 im_info
             )
-        roi_feat_3rd = roi_extractor.get_roi_feature(rcnn_feat, proposal_3rd, "3rd")
+        roi_feat_3rd = roi_extractor.get_roi_feature(rcnn_feat, proposal_3rd)
         bbox_loss_3rd = bbox_head_3rd.get_loss(
             roi_feat_3rd,
             bbox_cls_3rd,

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -184,7 +184,6 @@ class CascadeNeck(Neck):
 
 
 """
-difference:
 1. rename symbol via stage
 2. (decode_bbox -> proposal_target) rather than (proposal -> proposal_target)
 """
@@ -198,19 +197,19 @@ class CascadeBbox2fcHead(Bbox2fcHead):
         self._proposal              = None
 
         # for stage '1st_3rd', using weight from 1st stage
-        weight_stage = self.stage.split('_')[0]
-        self.fc1_weight = X.var("bbox_fc1_" + weight_stage + "_weight")
-        self.fc2_weight = X.var("bbox_fc2_" + weight_stage + "_weight")
+        stage = self.stage.split('_')[0]
+        self.fc1_weight = X.var("bbox_fc1_%s_weight" % stage)
+        self.fc2_weight = X.var("bbox_fc2_%s_weight" % stage)
         self.cls_logit_weight = X.var(
-            "bbox_cls_logit_" + weight_stage + "_weight",
+            "bbox_cls_logit_%s_weight" % stage,
             init=X.gauss(0.01)
         )
-        self.cls_logit_bias = X.var("bbox_cls_logit_" + weight_stage + "_bias")
+        self.cls_logit_bias = X.var("bbox_cls_logit_%s_bias" % stage)
         self.bbox_delta_weight = X.var(
-            "bbox_reg_delta_" + weight_stage + "_weight",
+            "bbox_reg_delta_%s_weight" % stage,
             init=X.gauss(0.001)
         )
-        self.bbox_delta_bias = X.var("bbox_reg_delta_" + weight_stage + "_bias")
+        self.bbox_delta_bias = X.var("bbox_reg_delta_%s_bias" % stage)
 
 
     def _get_bbox_head_logit(self, conv_feat):

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -200,6 +200,8 @@ class CascadeBbox2fcHead(Bbox2fcHead):
         stage = self.stage.split('_')[0]
         self.fc1_weight = X.var("bbox_fc1_%s_weight" % stage)
         self.fc2_weight = X.var("bbox_fc2_%s_weight" % stage)
+        self.fc1_bias = X.var("bbox_fc1_%s_bias" % stage)
+        self.fc2_bias = X.var("bbox_fc2_%s_bias" % stage)
         self.cls_logit_weight = X.var(
             "bbox_cls_logit_%s_weight" % stage,
             init=X.gauss(0.01)
@@ -224,6 +226,8 @@ class CascadeBbox2fcHead(Bbox2fcHead):
             reshape,
             filter=1024,
             weight=self.fc1_weight,
+            bias=self.fc1_bias,
+            no_bias=False,
             name="bbox_fc1_" + stage
         )
         fc1_relu = X.relu(fc1, name="bbox_fc1_relu_" + stage)
@@ -231,6 +235,8 @@ class CascadeBbox2fcHead(Bbox2fcHead):
             fc1_relu,
             filter=1024,
             weight=self.fc2_weight,
+            bias=self.fc2_bias,
+            no_bias=False,
             name="bbox_fc2_" + stage
         )
         fc2_relu = X.relu(fc2, name="bbox_fc2_" + stage)

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -89,7 +89,7 @@ class CascadeRcnn(object):
         rcnn_feat = neck.get_rcnn_feature(rcnn_feat)
 
         # stage1
-        roi_feat = roi_extractor.get_roi_feature(rcnn_feat, proposal, "1st")
+        roi_feat = roi_extractor.get_roi_feature(rcnn_feat, proposal)
         _, bbox_xyxy = bbox_head.get_prediction(
             roi_feat,
             im_info,
@@ -98,7 +98,7 @@ class CascadeRcnn(object):
 
         # stage2
         proposal_2nd = bbox_xyxy
-        roi_feat_2nd = roi_extractor.get_roi_feature(rcnn_feat, proposal_2nd, "2nd")
+        roi_feat_2nd = roi_extractor.get_roi_feature(rcnn_feat, proposal_2nd)
         _, bbox_xyxy_2nd = bbox_head_2nd.get_prediction(
             roi_feat_2nd,
             im_info,
@@ -107,7 +107,7 @@ class CascadeRcnn(object):
 
         # stage3
         proposal_3rd = bbox_xyxy_2nd
-        roi_feat_3rd = roi_extractor.get_roi_feature(rcnn_feat, proposal_3rd, "3rd")
+        roi_feat_3rd = roi_extractor.get_roi_feature(rcnn_feat, proposal_3rd)
         cls_score_3rd, bbox_xyxy_3rd = bbox_head_3rd.get_prediction(
             roi_feat_3rd,
             im_info,
@@ -145,17 +145,17 @@ class CascadeRcnn(object):
         rcnn_feat = neck.get_rcnn_feature(rcnn_feat)
 
         # stage1
-        roi_feat = roi_extractor.get_roi_feature(rcnn_feat, proposal, "1st")
+        roi_feat = roi_extractor.get_roi_feature(rcnn_feat, proposal)
         _, bbox_xyxy = bbox_head.get_prediction(roi_feat, im_info, proposal)
 
         # stage2
         proposal_2nd = bbox_xyxy
-        roi_feat_2nd = roi_extractor.get_roi_feature(rcnn_feat, proposal_2nd, "2nd")
+        roi_feat_2nd = roi_extractor.get_roi_feature(rcnn_feat, proposal_2nd)
         _, bbox_xyxy_2nd = bbox_head_2nd.get_prediction(roi_feat_2nd, im_info, proposal_2nd)
 
         # stage3
         proposal_3rd = bbox_xyxy_2nd
-        roi_feat_3rd = roi_extractor.get_roi_feature(rcnn_feat, proposal_3rd, "3rd")
+        roi_feat_3rd = roi_extractor.get_roi_feature(rcnn_feat, proposal_3rd)
         cls_score_3rd, bbox_xyxy_3rd = bbox_head_3rd.get_prediction(roi_feat_3rd, im_info, proposal_3rd)
 
         # AR does not need score, just pass a dummy one
@@ -181,36 +181,6 @@ class CascadeNeck(Neck):
             name="conv_neck"
         )
         return conv_neck
-
-
-"""
-difference:
-1. rename symbol via stage
-"""
-class CascadeRoiAlign(RoiAlign):
-    def __init__(self, pRoi):
-        super().__init__(pRoi)
-
-    def get_roi_feature(self, rcnn_feat, proposal, stage):
-        p = self.p
-
-        if p.fp16:
-            rcnn_feat = X.to_fp32(rcnn_feat, "rcnn_feat_to_fp32_" + stage)
-
-        roi_feat = X.roi_align(
-            rcnn_feat,
-            rois=proposal,
-            out_size=p.out_size,
-            stride=p.stride,
-            name="roi_align_" + stage
-        )
-
-        if p.fp16:
-            roi_feat = X.to_fp16(roi_feat, "roi_feat_to_fp16_" + stage)
-
-        roi_feat = X.reshape(roi_feat, (-3, -2))
-
-        return roi_feat
 
 
 """

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -2,6 +2,7 @@ from __future__ import division
 from __future__ import print_function
 
 import math
+import mxnet as mx
 import mxnext as X
 
 from symbol.builder import FasterRcnn, Bbox2fcHead
@@ -128,7 +129,6 @@ class CascadeRcnn(object):
         )
 
         # average score between [1st_3rd, 2nd_3rd, 3rd]
-        import mxnet as mx
         cls_score_avg = mx.sym.add_n(cls_score_1st_3rd, cls_score_2nd_3rd, cls_score_3rd) / 3
 
         return X.group([rec_id, im_id, im_info, cls_score_avg, bbox_xyxy_3rd])

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -165,24 +165,6 @@ class CascadeRcnn(object):
             return X.group([rec_id, im_id, im_info, proposal_3rd, cls_score_3rd])
 
 
-class CascadeNeck(Neck):
-    def __init__(self, pNeck):
-        super().__init__(pNeck)
-
-    def get_rcnn_feature(self, rcnn_feat):
-        p = self.p
-        conv_channel = p.conv_channel
-
-        conv_neck = X.convrelu(
-            rcnn_feat,
-            filter=conv_channel,
-            no_bias=False,
-            init=X.gauss(0.01),
-            name="conv_neck"
-        )
-        return conv_neck
-
-
 """
 1. rename symbol via stage
 2. (decode_bbox -> proposal_target) rather than (proposal -> proposal_target)

--- a/models/cascade_rcnn/builder.py
+++ b/models/cascade_rcnn/builder.py
@@ -255,18 +255,22 @@ class CascadeBbox2fcHead(Bbox2fcHead):
 
         head_feat = self._get_bbox_head_logit(conv_feat)
 
+        if not isinstance(head_feat, dict):
+            head_feat = dict(classification=head_feat, regression=head_feat)
+
         if p.fp16:
-            head_feat = X.to_fp32(head_feat, name="bbox_head_to_fp32_" + stage)
+            head_feat["classification"] = X.to_fp32(head_feat["classification"], name="bbox_cls_head_to_fp32_" + stage)
+            head_feat["regression"] = X.to_fp32(head_feat["regression"], name="bbox_reg_head_to_fp32_" + stage)
 
         cls_logit = X.fc(
-            head_feat,
+            head_feat["classification"],
             filter=num_class,
             weight=self.cls_logit_weight,
             bias=self.cls_logit_bias,
             name='bbox_cls_logit_' + stage
         )
         bbox_delta = X.fc(
-            head_feat,
+            head_feat["regression"],
             filter=4 * num_reg_class,
             weight=self.bbox_delta_weight,
             bias=self.bbox_delta_bias,

--- a/operator_cxx/proposal_target-inl.h
+++ b/operator_cxx/proposal_target-inl.h
@@ -328,7 +328,7 @@ class ProposalTargetProp : public OperatorProperty {
     using namespace mshadow;
     CHECK_EQ(in_shape->size(), 2) << "Input:[rois, gt_boxes]";
     const TShape &dshape = in_shape->at(proposal_target_enum::kRois);
-    const int image_rois  = param_.image_rois == -1 ? dshape[1]: param_.image_rois;
+    const int image_rois  = param_.image_rois;
 
     auto output_rois_shape = Shape3(dshape[0], image_rois, 4);
     auto label_shape = Shape2(dshape[0], image_rois);

--- a/operator_cxx/proposal_target-inl.h
+++ b/operator_cxx/proposal_target-inl.h
@@ -142,8 +142,7 @@ class ProposalTargetOp : public Operator {
     const index_t num_image         = param_.batch_images;
     const index_t num_roi           = in_data[proposal_target_enum::kRois].Size() / (num_image * 4);
     const index_t num_gtbbox        = in_data[proposal_target_enum::kGtBboxes].Size() / (num_image * 5);
-    // when image_rois = -1 , keep out all rois without subsampling.
-    const int image_rois            = param_.image_rois == -1 ? num_roi : param_.image_rois;
+    const int image_rois            = param_.image_rois;
     Tensor<xpu, 3, DType> xpu_rois      = in_data[proposal_target_enum::kRois].
                                           get_with_shape<xpu, 3, DType>(Shape3(num_image, num_roi, 4), s);
     Tensor<xpu, 3, DType> xpu_gt_bboxes = in_data[proposal_target_enum::kGtBboxes].
@@ -175,9 +174,8 @@ class ProposalTargetOp : public Operator {
     for (index_t i = 0; i < num_image; ++i) {
       kept_rois.push_back(std::vector<Tensor<cpu, 1, DType>>());
       for (index_t j = 0; j < rois.size(1); ++j) {
-        // avoid filtering RoIs when image_rois equals to -1
         // y2 == 0 indicates padding
-        if (param_.image_rois == -1 || rois[i][j][3] > 0)
+        if (rois[i][j][3] > 0)
           kept_rois[i].push_back(rois[i][j]);
       }
       if (!param_.proposal_without_gt) {
@@ -238,7 +236,6 @@ class ProposalTargetOp : public Operator {
             param_.fg_thresh, 
             param_.bg_thresh_hi, 
             param_.bg_thresh_lo,
-            param_.image_rois,
             param_.class_agnostic,
             cpu_output_rois[i],
             cpu_labels[i],

--- a/operator_cxx/proposal_target-inl.h
+++ b/operator_cxx/proposal_target-inl.h
@@ -35,7 +35,6 @@ inline void SampleROI(
   const float fg_thresh,
   const float bg_thresh_hi,
   const float bg_thresh_lo,
-  const int image_rois,
   const bool class_agnostic,
   Tensor<cpu, 2, DType> &&rois,
   Tensor<cpu, 1, DType> &&labels,

--- a/operator_cxx/proposal_target.cc
+++ b/operator_cxx/proposal_target.cc
@@ -30,7 +30,6 @@ inline void SampleROI(const Tensor<cpu, 2, DType> &all_rois,
                       const float fg_thresh,
                       const float bg_thresh_hi,
                       const float bg_thresh_lo,
-                      const int image_rois,
                       const bool class_agnostic,
                       Tensor<cpu, 2, DType> &&rois,
                       Tensor<cpu, 1, DType> &&labels,
@@ -77,12 +76,9 @@ inline void SampleROI(const Tensor<cpu, 2, DType> &all_rois,
       neg_indexes.push_back(i);
     }
   }
-  // when image_rois != -1, subsampling rois
+  // subsampling rois
   index_t fg_rois_this_image;
-  if (image_rois != -1)
-    fg_rois_this_image = min<index_t>(fg_rois_per_image, fg_indexes.size());
-  else
-    fg_rois_this_image = fg_indexes.size();
+  fg_rois_this_image = min<index_t>(fg_rois_per_image, fg_indexes.size());
   if (fg_indexes.size() > fg_rois_this_image) {
     random_shuffle(begin(fg_indexes), end(fg_indexes));
     fg_indexes.resize(fg_rois_this_image);


### PR DESCRIPTION
1. remove special treatment for **image_roi** equals to -1, replaced by **number of rois** instead.
2. add Cascade R-CNN with FPN backbone.
3. remove **CascadeAlign** and **CascadeNeck**, replaced by **RoiAlign** and **ReduceNeck**.
4. add *bias* to 2fc head together with **Xavier** initialized *weight*.
5. add **sync_bn** and **gn** support.
6. update *v2* config to keep consistent with *v1*, except for **warmup**, resulting in convergence problem in *v2*.

Performance:
1. R-50 v2: 38.8
2. R-101 v2: 41.0
3. R-50 v1 FPN: 40.3 (mmdet is 40.4, and author's is 40.9)
4. R-101 v1 FPN: 42.3 (mmdet is 42.0, and author's is 42.9)
