### PR TITLE
Undefined name: import warnings for lines 135 and 140

### DIFF
--- a/utils/lr_scheduler.py
+++ b/utils/lr_scheduler.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from math import cos, pi
 from mxnet.lr_scheduler import LRScheduler
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/TuSimple/simpledet on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./core/detection_input.py:56:25: F821 undefined name 'NormParam'
        self.p = pNorm  # type: NormParam
                        ^
./core/detection_input.py:80:27: F821 undefined name 'ResizeParam'
        self.p = pResize  # type: ResizeParam
                          ^
./core/detection_input.py:120:27: F821 undefined name 'ResizeParam'
        self.p = pResize  # type: ResizeParam
                          ^
./core/detection_input.py:299:24: F821 undefined name 'PadParam'
        self.p = pPad  # type: PadParam
                       ^
./core/detection_input.py:330:24: F821 undefined name 'PadParam'
        self.p = pPad  # type: PadParam
                       ^
./core/detection_input.py:366:27: F821 undefined name 'AnchorTarget2DParam'
        self.p = pAnchor  # type: AnchorTarget2DParam
                          ^
./models/retinanet/input.py:20:25: F821 undefined name 'NormParam'
        self.p = pNorm  # type: NormParam
                        ^
./utils/lr_scheduler.py:134:13: F821 undefined name 'warnings'
            warnings.warn("baselr is deprecated. Please use base_lr.")
            ^
./utils/lr_scheduler.py:139:13: F821 undefined name 'warnings'
            warnings.warn("targetlr is deprecated. Please use target_lr.")
            ^
9     F821 undefined name 'NormParam'
9
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree