### PR TITLE
Fixed Bug： json_to_roidb.py has no attribute 'json' and test_loader.py has no num_thread

### DIFF
--- a/unittest/test_loader.py
+++ b/unittest/test_loader.py
@@ -23,7 +23,7 @@ class TestLoader(unittest.TestCase):
             label_name=label_name,
             batch_size=1,
             shuffle=True,
-            num_thread=1,
+            num_worker=1,
             kv=mx.kvstore.create(pKv.kvstore)
         )
         with self.assertRaises(StopIteration):
@@ -43,7 +43,7 @@ class TestLoader(unittest.TestCase):
             label_name=label_name,
             batch_size=1,
             shuffle=True,
-            num_thread=1,
+            num_worker=1,
             kv=mx.kvstore.create(pKv.kvstore)
         )
         with self.assertRaises(StopIteration):
@@ -63,7 +63,7 @@ class TestLoader(unittest.TestCase):
             label_name=label_name,
             batch_size=batch_size,
             shuffle=True,
-            num_thread=1,
+            num_worker=1,
             kv=mx.kvstore.create(pKv.kvstore)
         )
 

--- a/utils/json_to_roidb.py
+++ b/utils/json_to_roidb.py
@@ -9,8 +9,8 @@ import numpy as np
 def parse_argument():
     parser = argparse.ArgumentParser("Convert json gt to roidb")
     parser.add_argument("--json", type=str, required=True)
-    parser.parse_args()
-    return parser.json
+    args = parser.parse_args()
+    return args.json
 
 
 def json_to_roidb(json_path):


### PR DESCRIPTION
Describe the bug
A clear and concise description of what the bug is.
code in line 12-13
```
 parser.parse_args()
 return parser.json
```
are supossed to be change into
```
arg = parser.parse_args()
return arg.json
```
or you wil get

AttributeError: 'ArgumentParser' object has no attribute 'json'