### PR TITLE
fix pad2D potential error

### DIFF
--- a/core/detection_input.py
+++ b/core/detection_input.py
@@ -304,8 +304,9 @@ class Pad2DImageBbox(DetectionAugmentation):
         image = input_record["image"]
         gt_bbox = input_record["gt_bbox"]
 
+        origin_h, origin_w = input_record["h"], input_record["w"]
         h, w = image.shape[:2]
-        shape = (p.long, p.short, 3) if h >= w \
+        shape = (p.long, p.short, 3) if origin_h >= origin_w \
             else (p.short, p.long, 3)
 
         padded_image = np.zeros(shape, dtype=np.float32)
@@ -334,8 +335,9 @@ class Pad2DImage(DetectionAugmentation):
 
         image = input_record["image"]
 
+        origin_h, origin_w = input_record["h"], input_record["w"]
         h, w = image.shape[:2]
-        shape = (p.long, p.short, 3) if h >= w \
+        shape = (p.long, p.short, 3) if origin_h >= origin_w \
             else (p.short, p.long, 3)
 
         padded_image = np.zeros(shape, dtype=np.float32)


### PR DESCRIPTION
`Pad2DImageBbox` and `Pad2DImage` may pad images in the wrong direction when the values of width and height are very close. For instance, when resizing one image from (1835, 1836) to (800, 1200), the image size after `Resize2DImageBbox` is (800, 800), then `Pad2DImageBbox` will treat it as one "hight > width" image and pad it to (1200, 800).