### PR TITLE
Does anybody use TridentNet with MaskRCNN(FPN powered)?

### DIFF
--- a/models/tridentnet/builder.py
+++ b/models/tridentnet/builder.py
@@ -220,7 +220,7 @@ class TridentRpnHead(RpnHead):
 
         cls_logit, bbox_delta = self.get_output(conv_feat)
 
-        # TODO: remove this reshape hell
+        # TODO: remove this reshape hell, use sigmoid instead of softmax
         cls_logit_reshape = X.reshape(
             cls_logit,
             shape=(0, -4, 2, -1, 0, 0),  # (N,C,H,W) -> (N,2,C/2,H,W)


### PR DESCRIPTION
I feel there is no free lunch.
The three branches FPN RCNN Heads will be too heavy.
If we drop the FPN, the C4 feature maps resolution, both of the three branches are same, is not enough for small object instance segmentation.
Any hints by using TridentNet for instance segmentation?
Or, AutoFocus is a better choice?