### PR TITLE
better way for bbox clip in Resize2DImageBbox

### DIFF
--- a/core/detection_input.py
+++ b/core/detection_input.py
@@ -93,12 +93,8 @@ class Resize2DImageBbox(DetectionAugmentation):
                                            interpolation=cv2.INTER_LINEAR)
         # make sure gt boxes do not overflow
         gt_bbox[:, :4] = gt_bbox[:, :4] * scale
-        if image.shape[0] < image.shape[1]:
-            gt_bbox[:, [0, 2]] = np.clip(gt_bbox[:, [0, 2]], 0, p.long)
-            gt_bbox[:, [1, 3]] = np.clip(gt_bbox[:, [1, 3]], 0, p.short)
-        else:
-            gt_bbox[:, [0, 2]] = np.clip(gt_bbox[:, [0, 2]], 0, p.short)
-            gt_bbox[:, [1, 3]] = np.clip(gt_bbox[:, [1, 3]], 0, p.long)
+        gt_bbox[:, [0, 2]] = np.clip(gt_bbox[:, [0, 2]], 0, input_record["image"].shape[1] - 1)
+        gt_bbox[:, [1, 3]] = np.clip(gt_bbox[:, [1, 3]], 0, input_record["image"].shape[0] - 1)
         input_record["gt_bbox"] = gt_bbox
 
         # exactly as opencv

--- a/models/maskrcnn/input.py
+++ b/models/maskrcnn/input.py
@@ -38,12 +38,8 @@ class Resize2DImageBboxMask(DetectionAugmentation):
                                            interpolation=cv2.INTER_LINEAR)
         # make sure gt boxes do not overflow
         gt_bbox[:, :4] = gt_bbox[:, :4] * scale
-        if image.shape[0] < image.shape[1]:
-            gt_bbox[:, [0, 2]] = np.clip(gt_bbox[:, [0, 2]], 0, p.long)
-            gt_bbox[:, [1, 3]] = np.clip(gt_bbox[:, [1, 3]], 0, p.short)
-        else:
-            gt_bbox[:, [0, 2]] = np.clip(gt_bbox[:, [0, 2]], 0, p.short)
-            gt_bbox[:, [1, 3]] = np.clip(gt_bbox[:, [1, 3]], 0, p.long)
+        gt_bbox[:, [0, 2]] = np.clip(gt_bbox[:, [0, 2]], 0, input_record["image"].shape[1] - 1)
+        gt_bbox[:, [1, 3]] = np.clip(gt_bbox[:, [1, 3]], 0, input_record["image"].shape[0] - 1)
         input_record["gt_bbox"] = gt_bbox
 
         # exactly as opencv


### PR DESCRIPTION
Using p.long and p.short for bbox clip is not thread-safe when adopting RandResize2DImageBbox.